### PR TITLE
Feature/user profile pic

### DIFF
--- a/apps/server/routes/users.js
+++ b/apps/server/routes/users.js
@@ -3,11 +3,11 @@ const router = express.Router();
 import { PrismaClient } from "../generated/prisma/client.js";
 
 /**
- * Router for /api/factions
+ * Router for /api/users
  * @param {PrismaClient} prisma
  */
 export default function usersRouter(prisma) {
-  // POST /api/users/me
+  // GET /api/users/me
   router.get("/me", async (req, res) => {
     const dbUser = await prisma.user.findUnique({
       where: { id: req.user?.userId },
@@ -15,9 +15,37 @@ export default function usersRouter(prisma) {
         factions: true,
       },
     });
+
     if (dbUser == null) {
       return res.status(401).send({ error: "User not found." });
     }
+
+    return res.status(200).send({
+      id: dbUser.id,
+      username: dbUser.username,
+      email: dbUser.email,
+      imageUrl: dbUser.imageUrl,
+      nickname: dbUser.nickname,
+      factions: dbUser.factions,
+    });
+  });
+
+  // PATCH /api/users/me
+  router.patch("/me", async (req, res) => {
+    const { imageUrl } = req.body;
+
+    if (typeof imageUrl !== "string" || !imageUrl.startsWith("http")) {
+      return res.status(400).send({ error: "Invalid image URL." });
+    }
+
+    const dbUser = await prisma.user.update({
+      where: { id: req.user?.userId },
+      data: { imageUrl },
+      include: {
+        factions: true,
+      },
+    });
+
     return res.status(200).send({
       id: dbUser.id,
       username: dbUser.username,

--- a/apps/web/src/components/UserAvatar.jsx
+++ b/apps/web/src/components/UserAvatar.jsx
@@ -2,6 +2,14 @@ import { useMemo } from "react";
 import s from "../styles/modules/UserAvatar.module.css";
 import classNames from "classnames";
 
+const defaultAvatar = `data:image/svg+xml;utf8,${encodeURIComponent(`
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+    <circle cx="64" cy="64" r="64" fill="#b9bbbe"/>
+    <circle cx="64" cy="48" r="24" fill="#2f3136"/>
+    <path d="M24 110c6-22 23-34 40-34s34 12 40 34" fill="#2f3136"/>
+  </svg>
+`)}`;
+
 export default function UserAvatar({
   size = "md",
   imageUrl = "",
@@ -35,7 +43,7 @@ export default function UserAvatar({
             ? s.statusOffline
             : ""
       )}
-      src={imageUrl}
+      src={imageUrl?.trim() ? imageUrl : defaultAvatar}
       style={{
         "--avatarSize": `${imageSize}px`,
       }}

--- a/apps/web/src/components/UserPanel.jsx
+++ b/apps/web/src/components/UserPanel.jsx
@@ -1,19 +1,102 @@
+import { useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import s from "../styles/modules/UserPanel.module.css";
 import UserAvatar from "./UserAvatar";
 import { GearSixIcon, SignOutIcon } from "@phosphor-icons/react";
+import fileToBase64 from "../utils/fileToBase64";
+import shrinkImage from "../utils/shrinkImage";
 
 export default function UserPanel({ loggedInUser = {} }) {
   const nav = useNavigate();
+  const queryClient = useQueryClient();
+  const fileInput = useRef(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadProfileImage = async (file) => {
+    const smallerFile = file.size > 5 * 1024 * 1024 ? await shrinkImage(file) : file;
+    const image = await fileToBase64(smallerFile);
+
+    const uploadRes = await fetch("/api/assets/upload/image", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ image }),
+    });
+
+    if (!uploadRes.ok) {
+      throw new Error("Profile image upload failed");
+    }
+
+    const data = await uploadRes.json();
+
+    const saveRes = await fetch("/api/users/me", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ imageUrl: data.url }),
+    });
+
+    if (!saveRes.ok) {
+      throw new Error("Profile image update failed");
+    }
+
+    const updatedUser = await saveRes.json();
+
+    queryClient.setQueryData(["currentUser"], updatedUser);
+    queryClient.invalidateQueries({ queryKey: ["factionUsers"] });
+  };
+
+  const handleImageChange = async (e) => {
+    const file = e.target.files?.[0];
+
+    if (!file) return;
+
+    setIsUploading(true);
+
+    try {
+      await uploadProfileImage(file);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsUploading(false);
+
+      if (fileInput.current) {
+        fileInput.current.value = "";
+      }
+    }
+  };
+
   return (
     <div className={s.userPanel}>
-      <UserAvatar size="md" imageUrl={loggedInUser.imageUrl} />
+      <input
+        ref={fileInput}
+        type="file"
+        accept="image/*"
+        className={s.fileInput}
+        onChange={handleImageChange}
+      />
+
+      <button
+        type="button"
+        className={s.avatarButton}
+        onClick={() => fileInput.current?.click()}
+        disabled={isUploading}
+        title="Change profile picture"
+      >
+        <UserAvatar size="md" imageUrl={loggedInUser.imageUrl} />
+      </button>
+
       <div className={s.userInfo}>
         <h3>{loggedInUser.nickname}</h3>
         <p>
-          @{loggedInUser.username}&ensp;&bull;&ensp;<span>online</span>
+          @{loggedInUser.username}&ensp;&bull;&ensp;
+          <span>{isUploading ? "uploading..." : "online"}</span>
         </p>
       </div>
+
       <SignOutIcon
         weight="duotone"
         size={24}
@@ -28,6 +111,7 @@ export default function UserPanel({ loggedInUser = {} }) {
           });
         }}
       />
+
       <GearSixIcon weight="duotone" size={24} className={s.settingsIcon} />
     </div>
   );

--- a/apps/web/src/styles/modules/UserAvatar.module.css
+++ b/apps/web/src/styles/modules/UserAvatar.module.css
@@ -1,12 +1,11 @@
 .userAvatar {
   border-radius: 100%;
-  overflow: hidden;
-  background-image: url("https://upload.wikimedia.org/wikipedia/commons/7/7c/Profile_avatar_placeholder_large.png?_=20150327203541");
-  background-size: cover;
   height: var(--avatarSize) !important;
   width: var(--avatarSize) !important;
   flex-shrink: 0;
   flex-grow: 0;
+  object-fit: cover;
+  background-color: var(--clr-dark);
 }
 
 .userAvatar.statusOnline::after {

--- a/apps/web/src/styles/modules/UserPanel.module.css
+++ b/apps/web/src/styles/modules/UserPanel.module.css
@@ -40,3 +40,27 @@
 .settingsIcon:hover {
   transform: rotate(60deg);
 }
+
+.fileInput {
+  display: none;
+}
+
+.avatarButton {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatarButton:hover {
+  opacity: 0.85;
+}
+
+.avatarButton:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}

--- a/apps/web/src/styles/modules/UserPanel.module.css
+++ b/apps/web/src/styles/modules/UserPanel.module.css
@@ -54,6 +54,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-right: -0.5rem;
 }
 
 .avatarButton:hover {


### PR DESCRIPTION
This PR adds the ability for users to update their profile picture by clicking their avatar in the user panel.

Changes

1. Added a backend route for updating the logged-in user’s profile image
2. Added click-to-upload behavior on the user avatar
3. Reused the existing image upload flow for storing profile images
4. Updated the user cache so the new avatar shows right away
5. Replaced the default avatar placeholder with a cleaner built-in fallback

Notes
    No new packages were added for this change.